### PR TITLE
Got rid of matrix compliance dependency

### DIFF
--- a/src/nd4clj/matrix.clj
+++ b/src/nd4clj/matrix.clj
@@ -3,7 +3,6 @@
             [clojure.core.matrix :as m]
             [clojure.reflect :as r]
             [clojure.core.matrix.utils :as util]
-            [clojure.core.matrix.compliance-tester :as ct]
             [clojure.core.matrix.implementations :as imp])
   (:use [clojure.pprint :only [print-table]])
   (:import [org.nd4j.linalg.factory Nd4j]


### PR DESCRIPTION
Requiring nd4clj was resulting in a classpath error with core.matrix compliance testing. That dependency wasn;t being used in matrix.clj at all so I took it out.