### PR TITLE
Updating README to show setting current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ file.  Here is an example of usage.
             [clojure.core.matrix :as indarray])
   (:gen-class))
 
+  (indarray/set-current-implementation :nd4j)
+
 (def A (indarray/array [[0 1] [2 3]]))
 (def I (indarray/array [[1 0] [0 1]]))
 

--- a/src/nd4clj/matrix.clj
+++ b/src/nd4clj/matrix.clj
@@ -3,7 +3,6 @@
             [clojure.core.matrix :as m]
             [clojure.reflect :as r]
             [clojure.core.matrix.utils :as util]
-            [clojure.core.matrix.compliance-tester :as ct]
             [clojure.core.matrix.implementations :as imp])
   (:use [clojure.pprint :only [print-table]])
   (:import [org.nd4j.linalg.factory Nd4j]


### PR DESCRIPTION
I believe that this function has to be called in order for core.matrix to use nd4j implementation and not core.matrix's default. Felt that it would be best to put this in the README